### PR TITLE
"par" (<packaging>par</packaging>) is now accepted for virgo:deploy

### DIFF
--- a/virgo-maven-plugin/src/main/java/net/flybyte/virgo/maven/BaseMojo.java
+++ b/virgo-maven-plugin/src/main/java/net/flybyte/virgo/maven/BaseMojo.java
@@ -232,6 +232,8 @@ public abstract class BaseMojo extends AbstractMojo {
 			ext = "plan";
 		} else if ("virgo-par".equalsIgnoreCase(packaging)) {
 			ext = "par";
+		} else if ("par".equalsIgnoreCase(packaging)) {
+			ext = "par";
 		} else if ("virgo-property".equalsIgnoreCase(packaging)) {
 			ext = "properties";
 			throw new MojoFailureException("", new UnsupportedOperationException(


### PR DESCRIPTION
I just added another else block to accept "par". <packaging>par</packaging> is used by the org.apache.maven.plugins:maven-par-plugin. I've tested it with virgo-tomcat-server-3.6.2.RELEASE.

Would be great if we can change the SNAPSHOT to a release version.
